### PR TITLE
Refactor config to allow overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.swp
 *.pyc
 .status
-config.py
+/config.py
 client_secrets.json
 league

--- a/Readme.md
+++ b/Readme.md
@@ -28,7 +28,7 @@ You can find more info on how to build its components in the [doc folder](doc/HW
 
 To run the UI you'll need to install a few dependencies - you can find a list of the python packages in requirements.txt.
 Other dependencies you'll need on your system (raspbian packages) are: `libav-tools sox cec-utils`
-Copy the sample configuration and customize it according to your needs:
+Verify the default configuration in config_base.py and override it if necessary. To override config copy config.py.sample to config.py and edit it:
 ```
 cp config.py.sample config.py
 vi config.py

--- a/config.py.sample
+++ b/config.py.sample
@@ -1,84 +1,26 @@
-onscreen_leds_enabled = False
-standby_timeout_secs = 600
-bg_change_secs = 300
-bg_amount = 100
-hipchat_token = 'your_token'
-hipchat_room = 'your_room_id'
+""" Override config values from config_base using this file """
+from config_base import *
 
-min_goal_usecs = 1000
-min_secs_between_goals = 3
+""" Configure the plugin set """
+# -- Dev set
+# plugins = ['replay_debug', 'score', 'game', 'sound', 'io_debug', 'menu', 'control', 'league', 'event_debugger']
 
-# dev set
-plugins = ['replay_debug', 'score', 'game', 'sound', 'io_debug', 'menu', 'control', 'league', 'event_debugger']
+# -- Replays
+# plugins = ['replay', 'camera', 'score', 'game', 'sound', 'io_debug', 'menu', 'control', 'league', 'event_debugger']
 
-# full blown set: arduino, camera, league & sync, upload, chat
+# -- Full blown set: arduino, camera, league & sync, upload, chat
 # plugins = ['replay', 'camera', 'score', 'game', 'upload', 'sound', 'leds', 'io_debug', 'io_serial', 'standby', 'menu', 'control', 'hipbot', 'motiondetector', 'league', 'event_debugger', 'league_sync']
 
-show_instructions = True
+""" Configure paths """
+# -- replay path
+#replay_path = "..."
 
-replay_path = '/home/pi/replay'
-ignore_recent_chunks = 1
-short_chunks = 10
-long_chunks = 25
+# -- or the location of the file_handler
+#log["handlers"]["file_handler"]["filename"] = ""
 
-league_dir = './league'
-league_url = 'http://localhost:8888/api'
-league_apikey = 'put-your-apikey-here'
+""" Override tokens for plugins """
+#hipchat_token = 'your_token'
+#hipchat_room = 'your_room_id'
 
-# config parameters for motion detector
-# MV frame size
-md_size = (82, 46)
-# crop pixels on each size of the frame to avoid detecting movement outside of the table
-md_crop_x = 25
-# threshold to consider MV movement
-md_mv_threshold = 100000
-# number of vectors to consider frame to contain movement
-md_min_vectors = 30
-# number of contiguous frames to required to consider it movemen
-md_min_frames = 9
-
-# send people_stop_playing event after X seconds without movement
-md_ev_absence_timeout = 30
-# send movement_detected every X seconds
-md_ev_interval = 2
-
-log = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "simple": {
-            "format": "%(asctime)s %(levelname)6s %(name)s - %(message)s",
-            "datefmt": "%H:%M:%S"
-        }
-    },
-
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "level": "DEBUG",
-            "stream": "ext://sys.stdout"
-        },
-
-        "file_handler": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "level": "DEBUG",
-            "formatter": "simple",
-            "filename": "/home/pi/event.log",
-            "maxBytes": 1000000,
-            "backupCount": 3
-        },
-    },
-
-    "loggers": {
-        "plugins.event_debugger": {
-            "level": "DEBUG",
-            "handlers": ["file_handler"],
-            "propagate": "no",
-
-        }
-    },
-    "root": {
-        "level": "INFO",
-        "handlers": ["console"]
-    }
-}
+#league_url = 'http://localhost:8888/api'
+#league_apikey = 'put-your-apikey-here'

--- a/config.py.sample
+++ b/config.py.sample
@@ -1,24 +1,42 @@
 """ Override config values from config_base using this file """
 from config_base import *
 
+
 """ Configure the plugin set """
-# -- Dev set
-# plugins = ['replay_debug', 'score', 'game', 'sound', 'io_debug', 'menu', 'control', 'league', 'event_debugger']
 
-# -- Replays
-# plugins = ['replay', 'camera', 'score', 'game', 'sound', 'io_debug', 'menu', 'control', 'league', 'event_debugger']
+# -- Enable camera, replays and video motiondetector
+#plugins.update(set(['replay', 'camera', 'motiondetector']))
 
-# -- Full blown set: arduino, camera, league & sync, upload, chat
-# plugins = ['replay', 'camera', 'score', 'game', 'upload', 'sound', 'leds', 'io_debug', 'io_serial', 'standby', 'menu', 'control', 'hipbot', 'motiondetector', 'league', 'event_debugger', 'league_sync']
+# -- Enable league sync with server
+#plugins.add('league_sync')
+
+# -- Enable Youtube video upload
+#plugins.add('upload')
+
+# -- Enable hipchat bot
+#plugins.add('hipbot')
+
+# -- Enable Arduino serial input and led output
+#plugins.add('io_serial')
+
+# -- Enable auto-TV standby
+#plugins.add('standby')
+
+# -- For development: sleep during replay
+#plugins.add('replay_debug')
+
 
 """ Configure paths """
+
 # -- replay path
 #replay_path = "..."
 
 # -- or the location of the file_handler
 #log["handlers"]["file_handler"]["filename"] = ""
 
+
 """ Override tokens for plugins """
+
 #hipchat_token = 'your_token'
 #hipchat_room = 'your_room_id'
 

--- a/config_base.py
+++ b/config_base.py
@@ -1,0 +1,88 @@
+onscreen_leds_enabled = False
+standby_timeout_secs = 600
+bg_change_secs = 300
+bg_amount = 100
+hipchat_token = 'your_token'
+hipchat_room = 'your_room_id'
+
+min_goal_usecs = 1000
+min_secs_between_goals = 3
+
+# dev set
+plugins = ['replay_debug', 'score', 'game', 'sound', 'io_debug', 'menu', 'control', 'league', 'event_debugger']
+
+# full blown set: arduino, camera, league & sync, upload, chat
+# plugins = ['replay', 'camera', 'score', 'game', 'upload', 'sound', 'leds', 'io_debug', 'io_serial', 'standby', 'menu', 'control', 'hipbot', 'motiondetector', 'league', 'event_debugger', 'league_sync']
+
+show_instructions = True
+
+replay_path = '/home/pi/replay'
+ignore_recent_chunks = 1
+short_chunks = 10
+long_chunks = 25
+
+league_dir = './league'
+league_url = 'http://localhost:8888/api'
+league_apikey = 'put-your-apikey-here'
+
+# config parameters for motion detector
+# MV frame size
+md_size = (82, 46)
+# crop pixels on each size of the frame to avoid detecting movement outside of the table
+md_crop_x = 25
+# threshold to consider MV movement
+md_mv_threshold = 100000
+# number of vectors to consider frame to contain movement
+md_min_vectors = 30
+# number of contiguous frames to required to consider it movemen
+md_min_frames = 9
+
+# send people_stop_playing event after X seconds without movement
+md_ev_absence_timeout = 30
+# send movement_detected every X seconds
+md_ev_interval = 2
+
+log = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "simple": {
+            "format": "%(asctime)s %(levelname)7s %(name)s - %(message)s",
+            "datefmt": "%H:%M:%S"
+        },
+        "console": {
+            "format": "%(levelname)7s - %(message)s"
+        }
+    },
+
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "DEBUG",
+            "formatter": "console",
+            "stream": "ext://sys.stdout"
+        },
+
+        "file_handler": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "level": "DEBUG",
+            "formatter": "simple",
+            "filename": "/home/pi/event.log",
+            "maxBytes": 1000000,
+            "backupCount": 3
+        },
+    },
+
+    "loggers": {
+        "plugins.event_debugger": {
+            "level": "DEBUG",
+            "handlers": ["file_handler"],
+            "propagate": "no",
+
+        }
+    },
+    "root": {
+        "level": "INFO",
+        "handlers": ["console"]
+    }
+}

--- a/config_base.py
+++ b/config_base.py
@@ -8,11 +8,8 @@ hipchat_room = 'your_room_id'
 min_goal_usecs = 1000
 min_secs_between_goals = 3
 
-# dev set
-plugins = ['replay_debug', 'score', 'game', 'sound', 'io_debug', 'menu', 'control', 'league', 'event_debugger']
-
-# full blown set: arduino, camera, league & sync, upload, chat
-# plugins = ['replay', 'camera', 'score', 'game', 'upload', 'sound', 'leds', 'io_debug', 'io_serial', 'standby', 'menu', 'control', 'hipbot', 'motiondetector', 'league', 'event_debugger', 'league_sync']
+# basic set of plugins
+plugins = set(['score', 'game', 'sound', 'io_debug', 'menu', 'control', 'league', 'leds'])
 
 show_instructions = True
 

--- a/foos.py
+++ b/foos.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-import config
+import foos.config as config
+
 import logging.config
 import sys
 import getopt

--- a/foos/config.py
+++ b/foos/config.py
@@ -1,0 +1,6 @@
+from config_base import *
+
+try:
+    from config import *
+except ImportError:
+    pass

--- a/foos/plugin_handler.py
+++ b/foos/plugin_handler.py
@@ -3,7 +3,7 @@ import atexit
 import pickle
 import importlib
 import logging
-import config
+import foos.config as config
 
 logger = logging.getLogger(__name__)
 

--- a/foos/ui/ui.py
+++ b/foos/ui/ui.py
@@ -24,7 +24,7 @@ from .anim import Move, Disappear, Wiggle, Delegate, ChangingTextures, ChangingT
 from .menu import Menu, MenuTree
 from .OutlineFont import OutlineFont
 from .FixedOutlineString import FixedOutlineString
-import config
+import foos.config as config
 import itertools
 
 media_path = ""

--- a/plugins/camera.py
+++ b/plugins/camera.py
@@ -1,7 +1,7 @@
 from subprocess import call
 from threading import Thread
 import time
-import config
+import foos.config as config
 
 
 class Plugin:

--- a/plugins/hipbot.py
+++ b/plugins/hipbot.py
@@ -1,4 +1,4 @@
-import config
+import foos.config as config
 import hipchat
 import logging
 

--- a/plugins/league.py
+++ b/plugins/league.py
@@ -9,7 +9,7 @@ import glob
 import shutil
 
 from foos.ui.ui import registerMenu
-import config
+import foos.config as config
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/league_sync.py
+++ b/plugins/league_sync.py
@@ -1,7 +1,7 @@
 import requests
 import threading
 import logging
-import config
+import foos.config as config
 import json
 
 from plugins.league import diskbackend

--- a/plugins/motiondetector.py
+++ b/plugins/motiondetector.py
@@ -5,7 +5,7 @@ import numpy as np
 import multiprocessing as mp
 import logging
 
-import config
+import foos.config as config
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/replay.py
+++ b/plugins/replay.py
@@ -1,4 +1,4 @@
-import config
+import foos.config as config
 import os
 from subprocess import call
 

--- a/plugins/replay_debug.py
+++ b/plugins/replay_debug.py
@@ -1,4 +1,4 @@
-import config
+import foos.config as config
 import os
 from subprocess import call
 import time

--- a/plugins/score.py
+++ b/plugins/score.py
@@ -2,7 +2,7 @@
 
 from collections import namedtuple
 import logging
-import config
+import foos.config as config
 
 from foos.clock import Clock
 

--- a/plugins/standby.py
+++ b/plugins/standby.py
@@ -1,7 +1,7 @@
 import time
 import threading
 import subprocess
-import config
+import foos.config as config
 import logging
 
 logger = logging.getLogger(__name__)

--- a/plugins/upload.py
+++ b/plugins/upload.py
@@ -7,7 +7,7 @@ import sys
 import time
 import logging
 import subprocess
-import config
+import foos.config as config
 from apiclient.discovery import build
 from apiclient.errors import HttpError
 from apiclient.http import MediaFileUpload


### PR DESCRIPTION
Benefits:
Default config available out of the box - no need to copy the sample file
Overrides for apiKeys and paths will be kept and it won't be necessary to keep updating the local file with the sample file if new config keys are added

The default config will be in config_base.py and will be checked in.
The regular config.py will be a set of overrides - either the whole file, as it has been now, or the now recommended way - simply override a few files.

config.py.sample will be the template for the new override format